### PR TITLE
[ignore] enable ci on merge queue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ on:
     tags:
       - v*
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
this was missing to be able to use the merge queue and be able to merge PRs. Currently we cannot merge PR.