### PR TITLE
[ENHANCEMENT]: Add ephemeral dashboard tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The `resources` field accepts the following resource names (case-insensitive, co
 | Resource | Description |
 |---------|-------------|
 | `dashboard` | Dashboard management tools |
+| `ephemeraldashboard` | Ephemeral dashboard management tools |
 | `project` | Project management tools |
 | `datasource` | Project-level datasource tools |
 | `globaldatasource` | Global datasource tools |
@@ -323,49 +324,83 @@ perses-mcp-server --config /path/to/config.yaml
 ## Tools
 
 > [!NOTE]  
-> When running in read-only mode (`read_only: true` in config), only tools that retrieve information are available. Write operations like `create_project`, `create_dashboard`, `create_global_datasource`, `update_global_datasource`, and `create_project_variable` are disabled in read-only mode.
+> When running in read-only mode (`read_only: true` in config), only tools that retrieve information are available. All write operations (create, update, delete) are disabled in read-only mode.
 
 ### Projects
 
-| Tool                         | Description           | Required Parameters |
-| ---------------------------- | --------------------- | ------------------- |
-| `perses_list_projects`       | List all projects     | -                   |
-| `perses_get_project_by_name` | Get a project by name | `project`           |
-| `perses_create_project`      | Create a new project  | `project`           |
+| Tool                         | Description                  | Required Parameters |
+| ---------------------------- | ---------------------------- | ------------------- |
+| `perses_list_projects`       | List all projects            | -                   |
+| `perses_get_project_by_name` | Get a project by name        | `name`              |
+| `perses_create_project`      | Create a new project         | `project`           |
+| `perses_update_project`      | Update an existing project   | `name`              |
+| `perses_delete_project`      | Delete a project             | `name`              |
 
 ### Dashboards
 
 | Tool                           | Description                                                    | Required Parameters    |
 | ------------------------------ | -------------------------------------------------------------- | ---------------------- |
 | `perses_list_dashboards`       | List all dashboards for a specific project                     | `project`              |
-| `perses_get_dashboard_by_name` | Get a dashboard by name for a project                          | `project`, `dashboard` |
+| `perses_get_dashboard_by_name` | Get a dashboard by name for a project                          | `project`, `name`      |
 | `perses_create_dashboard`      | Create a dashboard given a project and dashboard configuration | `project`, `dashboard` |
+| `perses_update_dashboard`      | Update an existing dashboard in a project                      | `project`, `dashboard` |
+| `perses_delete_dashboard`      | Delete a dashboard from a project                              | `project`, `name`      |
 
 For dashboard configuration, see [Perses Dashboards](https://github.com/perses/perses/blob/main/docs/api/dashboard.md)
 
+### Ephemeral Dashboards
+
+Ephemeral dashboards are temporary dashboards with a TTL (time-to-live). They are automatically cleaned up after expiry.
+
+| Tool                                     | Description                                                               | Required Parameters    |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ---------------------- |
+| `perses_list_ephemeral_dashboards`       | List all ephemeral dashboards for a specific project                      | `project`              |
+| `perses_get_ephemeral_dashboard_by_name` | Get an ephemeral dashboard by name for a project                          | `project`, `name`      |
+| `perses_create_ephemeral_dashboard`      | Create an ephemeral dashboard given a project and dashboard configuration | `project`, `dashboard` |
+| `perses_update_ephemeral_dashboard`      | Update an existing ephemeral dashboard in a project                       | `project`, `dashboard` |
+| `perses_delete_ephemeral_dashboard`      | Delete an ephemeral dashboard from a project                              | `project`, `name`      |
+
+For ephemeral dashboard configuration, see [Perses EphemeralDashboard](https://github.com/perses/perses/blob/main/docs/api/ephemeral-dashboard.md)
+
 ### Datasources
 
-| Tool                                    | Description                                 | Required Parameters     | Optional Parameters          |
-| --------------------------------------- | ------------------------------------------- | ----------------------- | ---------------------------- |
-| `perses_list_global_datasources`        | List all global datasources                 | -                       | -                            |
-| `perses_list_datasources`               | List all datasources for a specific project | `project`               | -                            |
-| `perses_get_global_datasource_by_name`  | Get a global datasource by name             | `datasource`            | -                            |
-| `perses_get_project_datasource_by_name` | Get a project datasource by name            | `project`, `datasource` | -                            |
-| `perses_create_global_datasource`       | Create a new global datasource              | `name`, `type`, `url`   | `display_name`, `proxy_type` |
-| `perses_update_global_datasource`       | Update an existing global datasource        | `name`, `type`, `url`   | `display_name`, `proxy_type` |
+| Tool                                    | Description                                  | Required Parameters     | Optional Parameters          |
+| --------------------------------------- | -------------------------------------------- | ----------------------- | ---------------------------- |
+| `perses_list_global_datasources`        | List all global datasources                  | -                       | -                            |
+| `perses_get_global_datasource_by_name`  | Get a global datasource by name              | `name`                  | -                            |
+| `perses_create_global_datasource`       | Create a new global datasource               | `name`, `type`, `url`   | `display_name`, `proxy_type` |
+| `perses_update_global_datasource`       | Update an existing global datasource         | `name`, `type`, `url`   | `display_name`, `proxy_type` |
+| `perses_delete_global_datasource`       | Delete a global datasource                   | `name`                  | -                            |
+| `perses_list_project_datasources`       | List all datasources for a specific project  | `project`               | -                            |
+| `perses_get_project_datasource_by_name` | Get a project datasource by name             | `project`, `name`       | -                            |
+| `perses_create_project_datasource`      | Create a new datasource in a project         | `project`, `datasource` | -                            |
+| `perses_update_project_datasource`      | Update an existing datasource in a project   | `project`, `datasource` | -                            |
+| `perses_delete_project_datasource`      | Delete a datasource from a project           | `project`, `name`       | -                            |
 
 ### Roles
 
-| Tool                                      | Description                           | Required Parameters      |
-| ----------------------------------------- | ------------------------------------- | ------------------------ |
-| `perses_list_global_roles`                | List all global roles                 | -                        |
-| `perses_get_global_role_by_name`          | Get a global role by name             | `role`                   |
-| `perses_list_global_role_bindings`        | List all global role bindings         | -                        |
-| `perses_get_global_role_binding_by_name`  | Get a global role binding by name     | `roleBinding`            |
-| `perses_list_project_roles`               | List all roles for a specific project | `project`                |
-| `perses_get_project_role_by_name`         | Get a project role by name            | `project`, `role`        |
-| `perses_list_project_role_bindings`       | List all role bindings for a project  | `project`                |
-| `perses_get_project_role_binding_by_name` | Get a project role binding by name    | `project`, `roleBinding` |
+| Tool                                      | Description                              | Required Parameters      |
+| ----------------------------------------- | ---------------------------------------- | ------------------------ |
+| `perses_list_global_roles`                | List all global roles                    | -                        |
+| `perses_get_global_role_by_name`          | Get a global role by name                | `name`                   |
+| `perses_create_global_role`               | Create a new global role                 | `name`, `actions`, `scopes` |
+| `perses_update_global_role`               | Update an existing global role           | `name`, `actions`, `scopes` |
+| `perses_delete_global_role`               | Delete a global role                     | `name`                   |
+| `perses_list_global_role_bindings`        | List all global role bindings            | -                        |
+| `perses_get_global_role_binding_by_name`  | Get a global role binding by name        | `name`                   |
+| `perses_create_global_role_binding`       | Create a new global role binding         | `name`, `role`, `subjects` |
+| `perses_update_global_role_binding`       | Update an existing global role binding   | `name`, `role`, `subjects` |
+| `perses_delete_global_role_binding`       | Delete a global role binding             | `name`                   |
+| `perses_list_project_roles`               | List all roles for a specific project    | `project`                |
+| `perses_get_project_role_by_name`         | Get a project role by name               | `project`, `name`        |
+| `perses_create_project_role`              | Create a new project role                | `project`, `name`, `actions`, `scopes` |
+| `perses_update_project_role`              | Update an existing project role          | `project`, `name`, `actions`, `scopes` |
+| `perses_delete_project_role`              | Delete a project role                    | `project`, `name`        |
+| `perses_list_project_role_bindings`       | List all role bindings for a project     | `project`                |
+| `perses_get_project_role_binding_by_name` | Get a project role binding by name       | `project`, `name`        |
+| `perses_create_project_role_binding`      | Create a new project role binding        | `project`, `name`, `role`, `subjects` |
+| `perses_update_project_role_binding`      | Update an existing project role binding  | `project`, `name`, `role`, `subjects` |
+| `perses_delete_project_role_binding`      | Delete a project role binding            | `project`, `name`        |
 
 ### Plugins
 
@@ -378,10 +413,15 @@ For dashboard configuration, see [Perses Dashboards](https://github.com/perses/p
 | Tool                                  | Description                               | Required Parameters   |
 | ------------------------------------- | ----------------------------------------- | --------------------- |
 | `perses_list_global_variables`        | List all global variables                 | -                     |
-| `perses_get_global_variable_by_name`  | Get a global variable by name             | `variable`            |
-| `perses_list_variables`               | List all variables for a specific project | `project`             |
-| `perses_get_project_variable_by_name` | Get a project variable by name            | `project`, `variable` |
+| `perses_get_global_variable_by_name`  | Get a global variable by name             | `name`                |
+| `perses_create_global_variable`       | Create a new global variable              | `name`, `value`       |
+| `perses_update_global_variable`       | Update an existing global variable        | `name`, `value`       |
+| `perses_delete_global_variable`       | Delete a global variable                  | `name`                |
+| `perses_list_project_variables`       | List all variables for a specific project | `project`             |
+| `perses_get_project_variable_by_name` | Get a project variable by name            | `project`, `name`     |
 | `perses_create_project_variable`      | Create a project level variable           | `name`, `project`     |
+| `perses_update_project_variable`      | Update an existing project variable       | `project`, `name`, `value` |
+| `perses_delete_project_variable`      | Delete a project variable                 | `project`, `name`     |
 
 ## Local Development
 

--- a/internal/permcp/server.go
+++ b/internal/permcp/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/perses/mcp-server/pkg/tools"
 	"github.com/perses/mcp-server/pkg/tools/dashboard"
 	"github.com/perses/mcp-server/pkg/tools/datasource"
+	"github.com/perses/mcp-server/pkg/tools/ephemeraldashboard"
 	"github.com/perses/mcp-server/pkg/tools/globaldatasource"
 	"github.com/perses/mcp-server/pkg/tools/globalrole"
 	"github.com/perses/mcp-server/pkg/tools/globalrolebinding"
@@ -129,6 +130,7 @@ func (s *server) registerTools() {
 	resources := []resource.Resource{
 		project.New(s.persesClient),
 		dashboard.New(s.persesClient),
+		ephemeraldashboard.New(s.persesClient),
 		datasource.New(s.persesClient),
 		globaldatasource.New(s.persesClient),
 		role.New(s.persesClient),

--- a/pkg/tools/ephemeraldashboard/ephemeraldashboard.go
+++ b/pkg/tools/ephemeraldashboard/ephemeraldashboard.go
@@ -1,0 +1,354 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ephemeraldashboard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/perses/mcp-server/pkg/tools"
+	"github.com/perses/mcp-server/pkg/tools/resource"
+	apiClient "github.com/perses/perses/pkg/client/api/v1"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+)
+
+type ephemeraldashboard struct {
+	client apiClient.ClientInterface
+}
+
+func New(client apiClient.ClientInterface) resource.Resource {
+	return &ephemeraldashboard{
+		client: client,
+	}
+}
+
+func (ed *ephemeraldashboard) GetTools() []*tools.Tool {
+	return []*tools.Tool{
+		ed.List(),
+		ed.Get(),
+		ed.Create(),
+		ed.Update(),
+		ed.Delete(),
+	}
+}
+
+type ListEphemeralDashboardsInput struct {
+	Project string `json:"project" jsonschema:"Project name to list ephemeral dashboards from"`
+}
+
+func (ed *ephemeraldashboard) List() *tools.Tool {
+	tool := &mcp.Tool{
+		Name:        "perses_list_ephemeral_dashboards",
+		Description: "List ephemeral dashboards for a specific project",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: jsonschema.Ptr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   jsonschema.Ptr(false),
+			ReadOnlyHint:    true,
+			Title:           "List ephemeral dashboards for a specific project in Perses",
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"project": {
+					Type:        "string",
+					Description: "Project name",
+					MinLength:   jsonschema.Ptr(1),
+					MaxLength:   jsonschema.Ptr(75),
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+				},
+			},
+			Required: []string{"project"},
+		},
+	}
+
+	handler := func(_ context.Context, _ *mcp.CallToolRequest, input ListEphemeralDashboardsInput) (*mcp.CallToolResult, any, error) { //nolint:unparam
+		response, err := ed.client.EphemeralDashboard(input.Project).List("")
+		if err != nil {
+			return nil, nil, fmt.Errorf("error retrieving ephemeral dashboards: %w", err)
+		}
+
+		text, err := json.Marshal(response)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error marshalling ephemeral dashboards: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: string(text),
+				},
+			},
+		}, nil, nil
+	}
+
+	return &tools.Tool{
+		MCPTool:      tool,
+		IsWriteTool:  false,
+		ResourceType: tools.EphemeralDashboardResource,
+		RegisterWith: func(server *mcp.Server) { mcp.AddTool(server, tool, handler) },
+	}
+}
+
+type GetEphemeralDashboardByNameInput struct {
+	Project string `json:"project" jsonschema:"Project name to retrieve the ephemeral dashboard from"`
+	Name    string `json:"name" jsonschema:"Ephemeral dashboard name to retrieve"`
+}
+
+func (ed *ephemeraldashboard) Get() *tools.Tool {
+	tool := &mcp.Tool{
+		Name:        "perses_get_ephemeral_dashboard_by_name",
+		Description: "Get an ephemeral dashboard by name in a specific project",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: jsonschema.Ptr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   jsonschema.Ptr(false),
+			ReadOnlyHint:    true,
+			Title:           "Gets an ephemeral dashboard by name in a specific project in Perses",
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"project": {
+					Type:        "string",
+					Description: "Project name",
+					MinLength:   jsonschema.Ptr(1),
+					MaxLength:   jsonschema.Ptr(75),
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+				},
+				"name": {
+					Type:        "string",
+					Description: "Ephemeral dashboard name",
+					MinLength:   jsonschema.Ptr(1),
+					MaxLength:   jsonschema.Ptr(75),
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+				},
+			},
+			Required: []string{"project", "name"},
+		},
+	}
+
+	handler := func(_ context.Context, _ *mcp.CallToolRequest, input GetEphemeralDashboardByNameInput) (*mcp.CallToolResult, any, error) { //nolint:unparam
+		response, err := ed.client.EphemeralDashboard(input.Project).Get(input.Name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error retrieving ephemeral dashboard '%s' in project '%s': %w", input.Name, input.Project, err)
+		}
+		return nil, response, nil
+	}
+
+	return &tools.Tool{
+		MCPTool:      tool,
+		IsWriteTool:  false,
+		ResourceType: tools.EphemeralDashboardResource,
+		RegisterWith: func(server *mcp.Server) { mcp.AddTool(server, tool, handler) },
+	}
+}
+
+type CreateEphemeralDashboardInput struct {
+	Project   string `json:"project" jsonschema:"Project name to create the ephemeral dashboard in"`
+	Dashboard string `json:"dashboard" jsonschema:"Ephemeral dashboard JSON as string"`
+}
+
+func (ed *ephemeraldashboard) Create() *tools.Tool {
+	tool := &mcp.Tool{
+		Name:        "perses_create_ephemeral_dashboard",
+		Description: "Create a new ephemeral dashboard in a specific project",
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"project": {
+					Type:        "string",
+					Description: "Project name",
+					MinLength:   jsonschema.Ptr(1),
+					MaxLength:   jsonschema.Ptr(75),
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+				},
+				"dashboard": {
+					Type:        "string",
+					Description: "Ephemeral dashboard JSON as string",
+				},
+			},
+			Required: []string{"project", "dashboard"},
+		},
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: jsonschema.Ptr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   jsonschema.Ptr(false),
+			ReadOnlyHint:    false,
+			Title:           "Creates a new ephemeral dashboard in a specific project in Perses",
+		},
+	}
+
+	handler := func(_ context.Context, _ *mcp.CallToolRequest, input CreateEphemeralDashboardInput) (*mcp.CallToolResult, any, error) { //nolint:unparam
+		var dashboardObj v1.EphemeralDashboard
+		if err := json.Unmarshal([]byte(input.Dashboard), &dashboardObj); err != nil {
+			return nil, nil, fmt.Errorf("invalid ephemeral dashboard JSON: %w", err)
+		}
+
+		createdDashboard, err := ed.client.EphemeralDashboard(input.Project).Create(&dashboardObj)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating ephemeral dashboard in project '%s': %w", input.Project, err)
+		}
+
+		dashboardJSON, err := json.Marshal(createdDashboard)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error marshalling created ephemeral dashboard: %w", err)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: string(dashboardJSON),
+				},
+			},
+		}, nil, nil
+	}
+
+	return &tools.Tool{
+		MCPTool:      tool,
+		IsWriteTool:  true,
+		ResourceType: tools.EphemeralDashboardResource,
+		RegisterWith: func(server *mcp.Server) { mcp.AddTool(server, tool, handler) },
+	}
+}
+
+type UpdateEphemeralDashboardInput struct {
+	Project   string `json:"project" jsonschema:"Project name to update the ephemeral dashboard in"`
+	Dashboard string `json:"dashboard" jsonschema:"Ephemeral dashboard JSON as string"`
+}
+
+func (ed *ephemeraldashboard) Update() *tools.Tool {
+	tool := &mcp.Tool{
+		Name:        "perses_update_ephemeral_dashboard",
+		Description: "Update an existing ephemeral dashboard in a specific project",
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"project": {
+					Type:        "string",
+					Description: "Project name",
+					MinLength:   jsonschema.Ptr(1),
+					MaxLength:   jsonschema.Ptr(75),
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+				},
+				"dashboard": {
+					Type:        "string",
+					Description: "Ephemeral dashboard JSON as string",
+				},
+			},
+			Required: []string{"project", "dashboard"},
+		},
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: jsonschema.Ptr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   jsonschema.Ptr(false),
+			ReadOnlyHint:    false,
+			Title:           "Updates an existing ephemeral dashboard in a specific project in Perses",
+		},
+	}
+
+	handler := func(_ context.Context, _ *mcp.CallToolRequest, input UpdateEphemeralDashboardInput) (*mcp.CallToolResult, any, error) { //nolint:unparam
+		var dashboardObj v1.EphemeralDashboard
+		if err := json.Unmarshal([]byte(input.Dashboard), &dashboardObj); err != nil {
+			return nil, nil, fmt.Errorf("invalid ephemeral dashboard JSON: %w", err)
+		}
+
+		updatedDashboard, err := ed.client.EphemeralDashboard(input.Project).Update(&dashboardObj)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error updating ephemeral dashboard in project '%s': %w", input.Project, err)
+		}
+
+		dashboardJSON, err := json.Marshal(updatedDashboard)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error marshalling updated ephemeral dashboard: %w", err)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: string(dashboardJSON),
+				},
+			},
+		}, nil, nil
+	}
+
+	return &tools.Tool{
+		MCPTool:      tool,
+		IsWriteTool:  true,
+		ResourceType: tools.EphemeralDashboardResource,
+		RegisterWith: func(server *mcp.Server) { mcp.AddTool(server, tool, handler) },
+	}
+}
+
+type DeleteEphemeralDashboardInput struct {
+	Project string `json:"project" jsonschema:"Project name"`
+	Name    string `json:"name" jsonschema:"Ephemeral dashboard name to delete"`
+}
+
+func (ed *ephemeraldashboard) Delete() *tools.Tool {
+	tool := &mcp.Tool{
+		Name:        "perses_delete_ephemeral_dashboard",
+		Description: "Delete an ephemeral dashboard from a specific project",
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"project": {
+					Type:        "string",
+					Description: "Project name",
+					MinLength:   jsonschema.Ptr(1),
+					MaxLength:   jsonschema.Ptr(75),
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+				},
+				"name": {
+					Type:        "string",
+					Description: "Ephemeral dashboard name",
+					MinLength:   jsonschema.Ptr(1),
+					MaxLength:   jsonschema.Ptr(75),
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+				},
+			},
+			Required: []string{"project", "name"},
+		},
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: jsonschema.Ptr(true),
+			IdempotentHint:  true,
+			OpenWorldHint:   jsonschema.Ptr(false),
+			ReadOnlyHint:    false,
+			Title:           "Deletes an ephemeral dashboard from a specific project in Perses",
+		},
+	}
+
+	handler := func(_ context.Context, _ *mcp.CallToolRequest, input DeleteEphemeralDashboardInput) (*mcp.CallToolResult, any, error) { //nolint:unparam
+		err := ed.client.EphemeralDashboard(input.Project).Delete(input.Name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error deleting ephemeral dashboard '%s' in project '%s': %w", input.Name, input.Project, err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: fmt.Sprintf("Ephemeral dashboard '%s' deleted successfully from project '%s'", input.Name, input.Project),
+				},
+			},
+		}, nil, nil
+	}
+
+	return &tools.Tool{
+		MCPTool:      tool,
+		IsWriteTool:  true,
+		ResourceType: tools.EphemeralDashboardResource,
+		RegisterWith: func(server *mcp.Server) { mcp.AddTool(server, tool, handler) },
+	}
+}

--- a/pkg/tools/tool.go
+++ b/pkg/tools/tool.go
@@ -18,21 +18,23 @@ import "github.com/modelcontextprotocol/go-sdk/mcp"
 type Resource string
 
 const (
-	DashboardResource         Resource = "dashboard"
-	DatasourceResource        Resource = "datasource"
-	ProjectResource           Resource = "project"
-	GlobalDatasourceResource  Resource = "globaldatasource"
-	RoleResource              Resource = "role"
-	GlobalRoleResource        Resource = "globalrole"
-	RoleBindingResource       Resource = "rolebinding"
-	GlobalRoleBindingResource Resource = "globalrolebinding"
-	VariableResource          Resource = "variable"
-	GlobalVariableResource    Resource = "globalvariable"
-	PluginResource            Resource = "plugin"
+	DashboardResource          Resource = "dashboard"
+	EphemeralDashboardResource Resource = "ephemeraldashboard"
+	DatasourceResource         Resource = "datasource"
+	ProjectResource            Resource = "project"
+	GlobalDatasourceResource   Resource = "globaldatasource"
+	RoleResource               Resource = "role"
+	GlobalRoleResource         Resource = "globalrole"
+	RoleBindingResource        Resource = "rolebinding"
+	GlobalRoleBindingResource  Resource = "globalrolebinding"
+	VariableResource           Resource = "variable"
+	GlobalVariableResource     Resource = "globalvariable"
+	PluginResource             Resource = "plugin"
 )
 
 var ValidResources = []Resource{
 	DashboardResource,
+	EphemeralDashboardResource,
 	DatasourceResource,
 	ProjectResource,
 	GlobalDatasourceResource,


### PR DESCRIPTION
Closes #93 
## What's Been Implemented
Complete CRUD operations for ephemeral dashboards:
- `perses_list_ephemeral_dashboards` - List all ephemeral dashboards for a specific project
- `perses_get_ephemeral_dashboard_by_name` - Get an ephemeral dashboard by name
- `perses_create_ephemeral_dashboard` - Create a new ephemeral dashboard
- `perses_update_ephemeral_dashboard` - Update an existing ephemeral dashboard
- `perses_delete_ephemeral_dashboard` - Delete an ephemeral dashboard

Updated README.md with complete tool documentation

## Use Cases
   - Create dashboards for one-time data analysis and automatically clean them up
   - Example: Quick performance investigation during incidents
   - Generate temporary dashboards as part of automated reporting pipelines
   - Automatically expire after the report is consumed
   - No manual cleanup required
   - Create test dashboards via LLM/Claude that automatically clean up
   - Better resource management


